### PR TITLE
Fix HashSetEventHandler might cause EventStateManager to have incorrect handler count

### DIFF
--- a/api/AltV.Net.Shared/Events/HashSetEventHandler.cs
+++ b/api/AltV.Net.Shared/Events/HashSetEventHandler.cs
@@ -18,15 +18,19 @@ namespace AltV.Net.Shared.Events
         public void Add(TEvent value)
         {
             if (value == null) return;
-            if (type != null) core.EventStateManager.AddHandler(type.Value);
-            events.Add(value);
+            if (events.Add(value))
+            {
+                if (type != null) core.EventStateManager.AddHandler(type.Value);
+            }
         }
 
         public void Remove(TEvent value)
         {
             if (value == null) return;
-            if (type != null) core.EventStateManager.RemoveHandler(type.Value);
-            events.Remove(value);
+            if (events.Remove(value))
+            {
+                if (type != null) core.EventStateManager.RemoveHandler(type.Value);
+            }
         }
 
         public HashSet<TEvent> GetEvents() => events;


### PR DESCRIPTION
Consider this example:

```csharp
Alt.OnKeyUp += Handler1;
Alt.OnKeyUp += Handler2;

Alt.OnKeyUp -= Handler1;
Alt.OnKeyUp -= Handler1; // yes, twice.
```

With the current behaviour, it will cause the HandlerCount of EventStateManager drops to 0, therefore the keyboard event will be turned off with `Core_ToggleEvent` and Handler2 will not be fired after that.

So, I think it would be better to add a check if `HashSet<TEvent>.Add` and `HashSet<TEvent>.Remove` returns a successful result before doing anything with `EventStateManager`.